### PR TITLE
Increase sleep timeout to allow taking only 2 screenshots a second

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 npm-debug.log
+
+# IDEs
+.idea
+.vscode

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default class captureVisibleTabFull {
             return base.then(() => {
                 return this._sendMessage(tab, {'type': 'doScroll', index});
             }).then(({top, left}) => {
-                return this._sleep(300).then(() => ({top, left}));
+                return this._sleep(500).then(() => ({top, left}));
             }).then(({top, left}) => {
                 return this._doCapture(tab).then((dataURI) => ({dataURI, top, left}));
             }).then(({dataURI, top, left}) => {


### PR DESCRIPTION
As described in this [pull request comment](https://github.com/kyo-ago/chrome-tab-capture-visible-tab-full/pull/2#discussion_r1532705007), the official documentation states one can only take at most 2 screenshots a second. Setting 500 as the minimum might be ideal to avoid the following error

`This request exceeds the MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND quota`

Below is a snippet from the official documentation:

![image](https://github.com/kan/chrome-tab-capture-visible-tab-full/assets/19529979/0176d370-fa1c-451f-9966-eefba05eca1a)
